### PR TITLE
don't fail an entire like() array because one method doesn't suit a value

### DIFF
--- a/main.js
+++ b/main.js
@@ -41,16 +41,21 @@ Feels.prototype.like = function(methods) {
     } else {
       var _this = this;
       var like = 0;
+      var count = 0;
 
       methods.forEach(function(n) {
         if (_methods[n.toUpperCase()]) {
-          like += _this[_methods[n.toUpperCase()].f]();
+          try {
+            like += _this[_methods[n.toUpperCase()].f]();
+            count++;
+          } catch (e) { }
         } else {
           throw new Error('Methods must be one of: HI, HI_CA, AAT, WCI');
         }
       });
 
-      return like / methods.length;
+      if (count === 0) throw new Error('No valid methods for these values');
+      return like / count;
     }
   } else {
     if (temp <= 0) {

--- a/test/classMethods.js
+++ b/test/classMethods.js
@@ -229,8 +229,12 @@ describe('Feels()', function() {
         should(feels.like(['HI', 'HI_CA'])).be.approximately(22.51, 0.01);
       });
 
-      it('should throw', function() {
-        should(function() {return feels.like(['AAT', 'WCI']);}).throw('Wind Chill temp must be <= (0C, 32F, 273.15K)');
+      it('should ignore invalid algorithm / value combinations', function() {
+        should(feels.like(['AAT', 'WCI'])).be.equal(feels.like(['AAT']));
+      });
+
+      it('should throw if no valid method exists', function() {
+        should(function() {return feels.like('WCI');}).throw('Wind Chill temp must be <= (0C, 32F, 273.15K)');
       });
 
       it('should throw', function() {


### PR DESCRIPTION
Very cool module! I was surprised and happy to find it as I'm hacking on a little climate visualization project right now.

One thing I've run into is this: I'm applying a set of methods ('HI', 'AAT', 'WCI') to a very large set of weather data, some of which is valid for only a subset of the methods. Currently, all methods must be valid on all data points or the whole `like()` operation throws.

This PR includes tests and an implementation that attempts to run all valid methods, even if some methods aren't runnable, and only throws if no valid methods are found.
